### PR TITLE
Implemented models as @typedefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ Open http://<app_host>:<app_port>/api-docs in your browser to view the documenta
 exports.foo = function() {}
 ```
 
+For model definitions:
+
+```
+/**
+ * @typedef Point
+ * @property {integer} x.required
+ * @property {integer} y.required
+ * @property {string} color
+ */
+
+ // Now I can use it as below:
+
+ /**
+  * Insert a point
+  * @route POST /api/point
+  * @param {Point.model} point.body.required - the new point
+  */
+```
+
 #### More
 
 This module is based on [express-swaggerize-ui](https://github.com/pgroot/express-swaggerize-ui) and [Doctrine-File](https://github.com/researchgate/doctrine-file)

--- a/lib/swagger-helpers.js
+++ b/lib/swagger-helpers.js
@@ -144,8 +144,8 @@ function _organizeSwaggerProperties(swaggerObject, pathObject, propertyName) {
     'consumes',
     'produce',
     'produces',
-    'path',
-    'paths',
+    // 'path',
+    // 'paths',
     'schema',
     'schemas',
     'securityDefinition',
@@ -178,10 +178,19 @@ function _organizeSwaggerProperties(swaggerObject, pathObject, propertyName) {
     });
   // Paths.
   } else {
-    swaggerObject.paths[propertyName] = _objectMerge(
-      swaggerObject.paths[propertyName], pathObject[propertyName]
-    );
-  }
+    var routes = Object
+      .getOwnPropertyNames(pathObject[propertyName]);
+  
+    for (var k = 0; k < routes.length; k = k + 1) {
+      var route = routes[k];
+      if(!swaggerObject.paths){
+        swaggerObject.paths = {};
+      }
+      swaggerObject.paths[route] = _objectMerge(
+        swaggerObject.paths[route], pathObject[propertyName][route]
+        );
+    }
+    }
 }
 
 /**

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -48,16 +48,16 @@ function parseField(str) {
 function parseType(obj) {
     if(!obj.name) return 'string';
     const spl = obj.name.split('.');
-    if(spl.length > 1 && spl[0] == 'models'){
-        return spl[1];
+    if(spl.length > 1 && spl[1] == 'models'){
+        return spl[0];
     }
     else return obj.name;
 }
 function parseSchema(obj){
     if(!obj.name) return undefined;
     const spl = obj.name.split('.');
-    if(spl.length > 1 && spl[0] == 'models'){
-        return { "$ref": "#/definitions/" + spl[1] };
+    if(spl.length > 1 && spl[1] == 'models'){
+        return { "$ref": "#/definitions/" + spl[0] };
     }
     else return undefined;
 }

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -71,12 +71,37 @@ function parseTag(tags) {
     return ['default', '']
 }
 
+function parseTypedef(tags){
+    const typeName = tags[0]['name'];
+    var details = {
+        required: [],
+        properties: {}
+    };
+    for(let i = 1; i < tags.length; i++){
+        if(tags[i].title == 'property'){
+            const propName = tags[i].name;
+            const required = propName.split('.')[1];
+            if(required){
+                details.required.push(propName);
+            }
+            details.properties[propName] = { type: parseType(tags[i].type) };
+        }
+    }
+    return {typeName, details};
+}
+
+
 function fileFormat(comments) {
 
-    let route, parameters = {}, params = [], tags = [];
+    let route, parameters = {}, params = [], tags = [], definitions = {};
     for (let i in comments) {
         let desc = parseDescription(comments);
         if (i == 'tags') {
+            if(comments[i].length > 0 && comments[i][0]['title'] && comments[i][0]['title'] == 'typedef'){
+                const typedefParsed = parseTypedef(comments[i]);
+                definitions[typedefParsed.typeName] = typedefParsed.details;
+                continue;
+            }
             for (let j in comments[i]) {
                 let title = comments[i][j]['title']
                 if (title == 'route') {
@@ -107,7 +132,7 @@ function fileFormat(comments) {
             parameters[route.uri][route.method]['responses'] = parseReturn(comments[i]);
         }
     }
-    return {parameters: parameters, tags: tags}
+    return {parameters: parameters, tags: tags, definitions: definitions}
 }
 
 /**
@@ -161,12 +186,12 @@ module.exports = function (app) {
         var apiFiles = convertGlobPaths(options.basedir, options.files);
 
         // Parse the documentation in the APIs array.
-        for (var i = 0; i < apiFiles.length; i = i + 1) {
-            var comments = parseApiFile(apiFiles[i]);
-            var comments = filterJsDocComments(comments);
+        for (let i = 0; i < apiFiles.length; i = i + 1) {
+            let parsed = parseApiFile(apiFiles[i]);
+            let comments = filterJsDocComments(parsed);
 
-            for (let i in comments) {
-                var parsed = fileFormat(comments[i])
+            for (let j in comments) {
+                var parsed = fileFormat(comments[j])
                 swaggerHelpers.addDataToSwaggerObject(swaggerObject, [{paths: parsed.parameters, tags: parsed.tags}]);
             }
         }

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -93,7 +93,8 @@ function parseTypedef(tags){
         if(tags[i].title == 'property'){
             const propName = tags[i].name;
             const required = propName.split('.')[1];
-            if(required){
+            if(required && required == 'required'){
+                propName = propName.split('.')[0];
                 details.required.push(propName);
             }
             details.properties[propName] = { 

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -66,7 +66,12 @@ function parseReturn(tags) {
     for (let i in tags) {
         if (tags[i]['title'] == 'returns' || tags[i]['title'] == 'return') {
             let description = tags[i]['description'].split("-")
-            rets[description[0]] = {description: description[1]}; //TODO: return types/schemas
+            rets[description[0]] = {description: description[1]};
+            const type = parseType(tags[i].type);
+            if(type){
+                rets[description[0]].type = type;
+                rets[description[0]].schema = parseSchema(tags[i].type)
+            }
         }
     }
     return rets

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -46,15 +46,27 @@ function parseField(str) {
     }
 }
 function parseType(obj) {
-
-    return obj.name || 'string'
+    if(!obj.name) return 'string';
+    const spl = obj.name.split('.');
+    if(spl.length > 1 && spl[0] == 'models'){
+        return spl[1];
+    }
+    else return obj.name;
+}
+function parseSchema(obj){
+    if(!obj.name) return undefined;
+    const spl = obj.name.split('.');
+    if(spl.length > 1 && spl[0] == 'models'){
+        return { "$ref": "#/definitions/" + spl[1] };
+    }
+    else return undefined;
 }
 function parseReturn(tags) {
     let rets = {}
     for (let i in tags) {
         if (tags[i]['title'] == 'returns' || tags[i]['title'] == 'return') {
             let description = tags[i]['description'].split("-")
-            rets[description[0]] = {description: description[1]}
+            rets[description[0]] = {description: description[1]}; //TODO: return types/schemas
         }
     }
     return rets
@@ -84,7 +96,10 @@ function parseTypedef(tags){
             if(required){
                 details.required.push(propName);
             }
-            details.properties[propName] = { type: parseType(tags[i].type) };
+            details.properties[propName] = { 
+                type: parseType(tags[i].type),
+                schema: parseSchema(tags[i].type)
+            };
         }
     }
     return {typeName, details};
@@ -124,7 +139,8 @@ function fileFormat(comments) {
                         in: field.parameter_type,
                         description: comments[i][j]['description'],
                         required: field.required,
-                        type: parseType(comments[i][j]['type'])
+                        type: parseType(comments[i][j]['type']),
+                        schema: parseSchema(comments[i][j]['type'])
                     })
                 }
             }

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -187,12 +187,12 @@ module.exports = function (app) {
 
         // Parse the documentation in the APIs array.
         for (let i = 0; i < apiFiles.length; i = i + 1) {
-            let parsed = parseApiFile(apiFiles[i]);
-            let comments = filterJsDocComments(parsed);
+            let parsedFile = parseApiFile(apiFiles[i]);
+            let comments = filterJsDocComments(parsedFile);
 
             for (let j in comments) {
                 var parsed = fileFormat(comments[j])
-                swaggerHelpers.addDataToSwaggerObject(swaggerObject, [{paths: parsed.parameters, tags: parsed.tags}]);
+                swaggerHelpers.addDataToSwaggerObject(swaggerObject, [{paths: parsed.parameters, tags: parsed.tags, definitions: parsed.definitions}]);
             }
         }
 

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -46,6 +46,7 @@ function parseField(str) {
     }
 }
 function parseType(obj) {
+    if(!obj) return undefined;
     if(!obj.name) return 'string';
     const spl = obj.name.split('.');
     if(spl.length > 1 && spl[1] == 'models'){

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -49,7 +49,7 @@ function parseType(obj) {
     if(!obj) return undefined;
     if(!obj.name) return 'string';
     const spl = obj.name.split('.');
-    if(spl.length > 1 && spl[1] == 'models'){
+    if(spl.length > 1 && spl[1] == 'model'){
         return spl[0];
     }
     else return obj.name;
@@ -57,7 +57,7 @@ function parseType(obj) {
 function parseSchema(obj){
     if(!obj.name) return undefined;
     const spl = obj.name.split('.');
-    if(spl.length > 1 && spl[1] == 'models'){
+    if(spl.length > 1 && spl[1] == 'model'){
         return { "$ref": "#/definitions/" + spl[0] };
     }
     else return undefined;

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -96,7 +96,7 @@ function parseTypedef(tags){
     };
     for(let i = 1; i < tags.length; i++){
         if(tags[i].title == 'property'){
-            const propName = tags[i].name;
+            let propName = tags[i].name;
             const required = propName.split('.')[1];
             if(required && required == 'required'){
                 propName = propName.split('.')[0];


### PR DESCRIPTION
* `@typedef`s now compile into `definitions` of the swagger file
* links to models with the `.model` suffix will get the appropriate schema
* path merge bug fixed