### PR TITLE
Extending generator to handle operationId, summary, consumes and prod…

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -159,24 +159,26 @@ function fileFormat(comments) {
 					})
 				}
 
-				if (title == 'operationId') {
+				if (title == 'operationId' && route) {
 					parameters[route.uri][route.method]['operationId'] = comments[i][j]['description'];
 				}
 
-				if (title == 'summary') {
+				if (title == 'summary' && route) {
 					parameters[route.uri][route.method]['summary'] = comments[i][j]['description'];
 				}
 
-				if (title == 'produces') {
+				if (title == 'produces' && route) {
 					parameters[route.uri][route.method]['produces'] = parseProduces(comments[i][j]['description']);
 				}
 
-				if (title == 'consumes') {
+				if (title == 'consumes' && route) {
 					parameters[route.uri][route.method]['consumes'] = parseConsumes(comments[i][j]['description']);
 				}
 
-				parameters[route.uri][route.method]['parameters'] = params;
-				parameters[route.uri][route.method]['responses'] = parseReturn(comments[i]);
+				if (route) {
+					parameters[route.uri][route.method]['parameters'] = params;
+					parameters[route.uri][route.method]['responses'] = parseReturn(comments[i]);
+				}
 			}
 		}
 	}

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -27,7 +27,6 @@ function parseApiFile(file) {
 	let comments = doctrineFile.parseFileContent(content, {unwrap: true, sloppy: true, tags: null, recoverable: true});
 	return comments;
 }
-
 function parseRoute(str) {
 	let split = str.split(" ")
 
@@ -86,6 +85,15 @@ function parseTag(tags) {
 		}
 	}
 	return ['default', '']
+}
+
+function parseProduces(str) {
+	return str.split(/\s+/);
+}
+
+
+function parseConsumes(str) {
+	return str.split(/\s+/);
 }
 
 function parseTypedef(tags){
@@ -150,6 +158,23 @@ function fileFormat(comments) {
 						schema: parseSchema(comments[i][j]['type'])
 					})
 				}
+
+				if (title == 'operationId') {
+					parameters[route.uri][route.method]['operationId'] = comments[i][j]['description'];
+				}
+
+				if (title == 'summary') {
+					parameters[route.uri][route.method]['summary'] = comments[i][j]['description'];
+				}
+
+				if (title == 'produces') {
+					parameters[route.uri][route.method]['produces'] = parseProduces(comments[i][j]['description']);
+				}
+
+				if (title == 'consumes') {
+					parameters[route.uri][route.method]['consumes'] = parseConsumes(comments[i][j]['description']);
+				}
+
 				parameters[route.uri][route.method]['parameters'] = params;
 				parameters[route.uri][route.method]['responses'] = parseReturn(comments[i]);
 			}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.1.0",
   "description": "Generates swagger doc & ui based on express existing routes.",
   "main": "index.js",
-  "scripts": {
-
-  },
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/pgroot/express-swagger-generator.git"


### PR DESCRIPTION
With this changes we are extending the generator to handle operationId, summary, consumes and produces annotations.
For example, having this:
```
/**
   * This function comment is parsed by doctrine
   * @route GET /foo
   * @operationId retrieveFooInfo
   * @produces application/json application/xml
   * @consumes application/json application/xml
   * @group foo-Operations about foo
   * @summary Retrieves foo information
   *
   * @param {string} name.query.required - name
   * @returns {Foo.model} 200 - A Foo object
   * @returns {Error}  default - Unexpected error
   */
```

It will add extra info to the path 

```
{
...
"operationId": "retrieveFooInfo",
"produces": [
"application/json",
"application/xml"
],
"consumes": [
"application/json",
"application/xml"
],
"summary": " Retrieves foo information"
...
```

