### PR TITLE
fix "required" error

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -184,6 +184,7 @@ function parseTypedef(tags) {
             let propName = tags[i].name;
             const required = propName.split('.')[1];
             if (required && required == 'required') {
+                if (details.required == null) details.required = [];
                 propName = propName.split('.')[0];
                 details.required.push(propName);
             }


### PR DESCRIPTION
if no "required" field is specified in scheme, swagger validator generate this error:
`{"level":"error","domain":"validation","keyword":"minItems","message":"array is too short: must have at least 1 elements but instance has 0 elements","schema":{"loadingURI":"http://json-schema.org/draft-04/schema#","pointer":"/definitions/stringArray"}`

because of generating json with empty "required" field in scheme