### PR TITLE
swagger.js exports 3 functions, default require() functionality maintained

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@
  * Created by GROOT on 3/27 0027.
  */
 
-module.exports = require('./lib/swagger');
+module.exports = require('./lib/swagger').generateSpecAndMount;

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -413,7 +413,7 @@ function convertGlobPaths(base, globs) {
  * @returns {array} Swagger spec
  * @requires swagger-parser
  */
-module.exports = function (app) {
+function generateSpecAndMount(app) {
 
     return function (options) {
         /* istanbul ignore if */
@@ -464,4 +464,11 @@ module.exports = function (app) {
         }));
         return swaggerObject;
     }
+};
+
+
+module.exports = {
+    generateSpecAndMount,
+    fileFormat,
+    parseApiFile
 };


### PR DESCRIPTION
This changes the object exported from swagger.js from the function that does everything, to an object with multiple functions in it. By changing index.js, the original behavior is maintained, but for those who want more control over the middleware and parsing pipeline, swagger.js now additional exposes `fileFormat` and `parseApiFile`. 

I'm using these entry points in my project to auto-generate documentation when the code changes. I might further suggest breaking out the code that defines routes on an express object from generateSpecAndMount to allow more control of the express server, but that is not necessary for my use case.