### PR TITLE
fix the description with /**

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -149,7 +149,9 @@ function parseReturn(tags) {
 }
 
 function parseDescription(obj) {
-    return obj.description || ''
+    const description = obj.description || '';
+    const sanitizedDescription = description.replace('/**','');
+    return sanitizedDescription;
 }
 
 function parseTag(tags) {


### PR DESCRIPTION
Fixed the problem the code comments are with space/identation before the text.
The description of documentation appear /** even dont not have description in the code.