### PR TITLE
Fix invalid schema when type has no required properties.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -175,7 +175,6 @@ function parseConsumes(str) {
 function parseTypedef(tags) {
     const typeName = tags[0]['name'];
     let details = {
-        required: [],
         properties: {}
     };
     if (tags[0].type && tags[0].type.name) {
@@ -191,7 +190,7 @@ function parseTypedef(tags) {
             let readOnly = props.indexOf('readOnly') > -1
 
             if (required) {
-                if (details.required == null) details.required = [];
+                if (typeof details.required === 'undefined') details.required = [];
                 propName = propName.split('.')[0];
                 details.required.push(propName);
             }


### PR DESCRIPTION
The Open API / Swagger specification states that if there
are no required properties, you must not include the required
property. It explicitly states that an empty array is invalid,
and the online editor also complains if required is null.

Change to remove the required property when initializing the
details object, it will only be added if a required property
exists on the type.